### PR TITLE
Be more selective grabbing logfiles

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,7 +265,8 @@ http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer
 		s3svc := s3.New(sess, nil)
 
 		// For now, get objects for just today.
-		totalPrefix := bucketPrefix + "/AWSLogs/" + accountID + "/elasticloadbalancing/" + region + nowPath
+		totalPrefix := bucketPrefix + "/AWSLogs/" + accountID + "/elasticloadbalancing/" + region + nowPath +
+		    "/" + accountID + "_elasticloadbalancing_" + region + "_" + lbName
 
 		logrus.WithFields(logrus.Fields{
 			"prefix": totalPrefix,


### PR DESCRIPTION
If there are more than one ELB worth of log files in the same S3 Prefix, honeyelb should not try upload every log file from every ELB each time that it tries to ingest logs for an ELB.