### PR TITLE
propogate sample rate set by the dynsampler to libhoney

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -190,6 +190,7 @@ func sendEvents(eventsCh <-chan event.Event) {
 		shaper.Shape("request", &ev)
 		libhEv := libhoney.NewEvent()
 		libhEv.Timestamp = ev.Timestamp
+		libhEv.SampleRate = uint(ev.SampleRate)
 		if err := libhEv.Add(ev.Data); err != nil {
 			logrus.WithFields(logrus.Fields{
 				"event": ev,


### PR DESCRIPTION
Looking at sample rates in ELB datasets, they appear fixed. I think this is because the sample rate is being set on the `honeytail/event.Event` object and not passed through to the `libhoney.Event` object when it's created. This PR fixes that.